### PR TITLE
Fixed stay option in runoff votes

### DIFF
--- a/plugins/addons/amxmodx/scripting/galileo.sma
+++ b/plugins/addons/amxmodx/scripting/galileo.sma
@@ -8424,7 +8424,7 @@ stock display_menu_clean( player_id, menuKeys )
     static menuClean[ MAX_BIG_BOSS_STRING ];
 
     static voteFooter   [ MAX_SHORT_STRING ];
-    static voteExtension[ MAX_SHORT_STRING ];
+    new voteExtension[ MAX_SHORT_STRING ];
     static menuHeader   [ MAX_SHORT_STRING / 2 ];
     static noneOption   [ MAX_SHORT_STRING / 2 ];
 


### PR DESCRIPTION
The stay option appears in runoff votes because it's declared as static, it keeps it's value from the original vote and shows it in the runoff vote because the next checks fail and it goes unchanged..